### PR TITLE
Setup timer correctly.

### DIFF
--- a/sys/mips/bcm471x/s5_machdep.c
+++ b/sys/mips/bcm471x/s5_machdep.c
@@ -238,9 +238,9 @@ platform_start(__register_t a0, __register_t a1, __register_t a2,
 
 	counter_freq = cpumult * refclock;
 # else
-//	platform_counter_freq = 200 * 1000 * 1000; /* Sentry5 is 200MHz */
-	platform_counter_freq = 480 * 1000 * 1000; /* BCM4718 is 200MHz */
+	platform_counter_freq = 500 * 1000 * 1000; /* BCM4718 is 500MHz */
 # endif
 
-	mips_timer_init_params(platform_counter_freq, 0);
+	/* BCM471x timer is 1/2 of Clk */
+	mips_timer_init_params(platform_counter_freq, 1);
 }


### PR DESCRIPTION
Our reference platform (RT-N16) is 500MHz and BCM471x timer is double counting, adjust for that.

With that I get correct time in single-user mode:

```
Timecounters tick every 10.000 msec
tcp_init: net.inet.tcp.tcbhashsize auto tuned to 512
md0: Embedded image 1331200 bytes at 0x8038b7b4
Trying to mount root from ufs:/dev/md0 []...
Mounting from ufs:/dev/md0 failed with error 22.
Trying to mount root from ufs:md0.uzip []...
warning: no time-of-day clock registered, system time will not be set accurately
start_init: trying /sbin/init
Mar  9 18:07:56 init: login_getclass: unknown class 'daemon'
sh: cannot open /etc/rc: No such file or directory
Enter full pathname of shell or RETURN for /bin/sh:
Cannot read termcap database;
using dumb terminal settings.
# sleep 60
#
```
